### PR TITLE
Feat: 회원별 시청내역 추천 스프링배치 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,7 @@ dependencies {
 	// Spring Batch
 	//****************************************************************
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
+	testImplementation 'org.springframework.batch:spring-batch-test'
 
 	////////////////////////////////////////////////////////////////////////////
 	//************************************************************************

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/config/HlsBatchConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/config/HlsBatchConfig.java
@@ -1,6 +1,7 @@
 package com.ssginc.showpingrefactoring.batch.config;
 
 import com.ssginc.showpingrefactoring.batch.listener.JobFailureListener;
+import com.ssginc.showpingrefactoring.batch.util.CustomRetryTemplate;
 import com.ssginc.showpingrefactoring.domain.stream.service.HlsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
@@ -12,8 +13,10 @@ import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -34,7 +37,7 @@ public class HlsBatchConfig {
      * @param createHlsStep    HLS 저장 Step
      * @return 생성된 HLS 저장 Job
      */
-    @Bean
+    @Bean (name = "createHlsJob")
     public Job createHlsJob(JobRepository jobRepository, Step createHlsStep) {
         return new JobBuilder("createHlsJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
@@ -54,14 +57,21 @@ public class HlsBatchConfig {
     @Bean
     public Step createHlsStep(JobRepository jobRepository,
                               PlatformTransactionManager tx,
-                              HlsService hlsService) {
+                              HlsService hlsService,
+                              @Qualifier("CustomRetryTemplate") RetryTemplate retryTemplate) {
+
         return new StepBuilder("createHlsStep", jobRepository)
                 .tasklet((contrib, ctx) -> {
                     String title = ctx.getStepContext()
                             .getStepExecution()
                             .getJobParameters()
                             .getString("title");
-                    hlsService.createHLS(title);
+
+                    retryTemplate.execute(retryContext -> {
+                        hlsService.createHLS(title);
+                        return null;
+                    });
+
                     return RepeatStatus.FINISHED;
                 }, tx)
                 .build();

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/config/HlsBatchConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/config/HlsBatchConfig.java
@@ -1,8 +1,11 @@
 package com.ssginc.showpingrefactoring.batch.config;
 
+import com.ssginc.showpingrefactoring.batch.listener.JobFailureListener;
 import com.ssginc.showpingrefactoring.domain.stream.service.HlsService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepListener;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
@@ -20,7 +23,10 @@ import org.springframework.transaction.PlatformTransactionManager;
  */
 @Configuration
 @EnableBatchProcessing
+@RequiredArgsConstructor
 public class HlsBatchConfig {
+
+    private final JobFailureListener jobFailureListener;
 
     /**
      * 지정된 JobRepository와 Step을 사용하여 HLS 저장 작업(Job)을 생성하는 메서드
@@ -33,6 +39,7 @@ public class HlsBatchConfig {
         return new JobBuilder("createHlsJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
                 .start(createHlsStep)
+                .listener(jobFailureListener)
                 .build();
     }
 

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/config/HlsBatchConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/config/HlsBatchConfig.java
@@ -1,0 +1,63 @@
+package com.ssginc.showpingrefactoring.batch.config;
+
+import com.ssginc.showpingrefactoring.domain.stream.service.HlsService;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * @author dckat
+ * HLS 배치 작업 구성하는 클래스
+ * <p>
+ */
+@Configuration
+@EnableBatchProcessing
+public class HlsBatchConfig {
+
+    /**
+     * 지정된 JobRepository와 Step을 사용하여 HLS 저장 작업(Job)을 생성하는 메서드
+     * @param jobRepository  JobRepository 객체
+     * @param createHlsStep    HLS 저장 Step
+     * @return 생성된 HLS 저장 Job
+     */
+    @Bean
+    public Job createHlsJob(JobRepository jobRepository, Step createHlsStep) {
+        return new JobBuilder("createHlsJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(createHlsStep)
+                .build();
+    }
+
+    /**
+     * 지정된 JobRepository, PlatformTransactionManager, 그리고 HlsService를 사용하여
+     * HLS 저장 Step을 생성하는 메서드
+     * @param jobRepository  JobRepository 객체
+     * @param tx             PlatformTransactionManager 객체
+     * @param hlsService     HlsService 객체
+     * @return 생성된 HLS 저장 Step
+     */
+    @Bean
+    public Step createHlsStep(JobRepository jobRepository,
+                              PlatformTransactionManager tx,
+                              HlsService hlsService) {
+        return new StepBuilder("createHlsStep", jobRepository)
+                .tasklet((contrib, ctx) -> {
+                    String title = ctx.getStepContext()
+                            .getStepExecution()
+                            .getJobParameters()
+                            .getString("title");
+                    hlsService.createHLS(title);
+                    return RepeatStatus.FINISHED;
+                }, tx)
+                .build();
+    }
+
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/config/SubtitleBatchConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/config/SubtitleBatchConfig.java
@@ -1,6 +1,8 @@
 package com.ssginc.showpingrefactoring.batch.config;
 
+import com.ssginc.showpingrefactoring.batch.listener.JobFailureListener;
 import com.ssginc.showpingrefactoring.domain.stream.service.SubtitleService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
@@ -20,7 +22,10 @@ import org.springframework.transaction.PlatformTransactionManager;
  */
 @Configuration
 @EnableBatchProcessing
+@RequiredArgsConstructor
 public class SubtitleBatchConfig {
+
+    private final JobFailureListener jobFailureListener;
 
     /**
      * 지정된 JobRepository와 Step을 사용하여 자막 생성 작업(Job)을 생성하는 메서드
@@ -33,6 +38,7 @@ public class SubtitleBatchConfig {
         return new JobBuilder("createSubtitleJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
                 .start(createSubtitleStep)
+                .listener(jobFailureListener)
                 .build();
     }
 

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/config/SubtitleBatchConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/config/SubtitleBatchConfig.java
@@ -11,8 +11,10 @@ import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -33,7 +35,7 @@ public class SubtitleBatchConfig {
      * @param createSubtitleStep  자막 생성 Step
      * @return 생성된 자막 생성 Job
      */
-    @Bean
+    @Bean(name = "createSubtitleJob")
     public Job createSubtitleJob(JobRepository jobRepository, Step createSubtitleStep) {
         return new JobBuilder("createSubtitleJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
@@ -53,14 +55,20 @@ public class SubtitleBatchConfig {
     @Bean
     public Step createSubtitleStep(JobRepository jobRepository,
                                    PlatformTransactionManager tx,
-                                   SubtitleService subtitleService) {
+                                   SubtitleService subtitleService,
+                                   @Qualifier("CustomRetryTemplate") RetryTemplate retryTemplate) {
         return new StepBuilder("createSubtitleStep", jobRepository)
                 .tasklet((contrib, ctx) -> {
                     String title = ctx.getStepContext()
                             .getStepExecution()
                             .getJobParameters()
                             .getString("title");
-                    subtitleService.createSubtitle(title);
+
+                    retryTemplate.execute(retryContext -> {
+                        subtitleService.createSubtitle(title);
+                        return null;
+                    });
+
                     return RepeatStatus.FINISHED;
                 }, tx)
                 .build();

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/config/SubtitleBatchConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/config/SubtitleBatchConfig.java
@@ -1,6 +1,5 @@
-package com.ssginc.showpingrefactoring.common.config;
+package com.ssginc.showpingrefactoring.batch.config;
 
-import com.ssginc.showpingrefactoring.domain.stream.service.HlsService;
 import com.ssginc.showpingrefactoring.domain.stream.service.SubtitleService;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -16,50 +15,12 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * @author dckat
- * 배치 작업 구성하는 클래스
+ * 자막 배치 작업 구성하는 클래스
  * <p>
  */
 @Configuration
 @EnableBatchProcessing
-public class BatchConfig {
-
-    /**
-     * 지정된 JobRepository와 Step을 사용하여 HLS 저장 작업(Job)을 생성하는 메서드
-     * @param jobRepository  JobRepository 객체
-     * @param createHlsStep    HLS 저장 Step
-     * @return 생성된 HLS 저장 Job
-     */
-    @Bean
-    public Job createHlsJob(JobRepository jobRepository, Step createHlsStep) {
-        return new JobBuilder("createHlsJob", jobRepository)
-                .incrementer(new RunIdIncrementer())
-                .start(createHlsStep)
-                .build();
-    }
-
-    /**
-     * 지정된 JobRepository, PlatformTransactionManager, 그리고 HlsService를 사용하여
-     * HLS 저장 Step을 생성하는 메서드
-     * @param jobRepository  JobRepository 객체
-     * @param tx             PlatformTransactionManager 객체
-     * @param hlsService     HlsService 객체
-     * @return 생성된 HLS 저장 Step
-     */
-    @Bean
-    public Step createHlsStep(JobRepository jobRepository,
-                            PlatformTransactionManager tx,
-                            HlsService hlsService) {
-        return new StepBuilder("createHlsStep", jobRepository)
-                .tasklet((contrib, ctx) -> {
-                    String title = ctx.getStepContext()
-                            .getStepExecution()
-                            .getJobParameters()
-                            .getString("title");
-                    hlsService.createHLS(title);
-                    return RepeatStatus.FINISHED;
-                }, tx)
-                .build();
-    }
+public class SubtitleBatchConfig {
 
     /**
      * 지정된 JobRepository와 Step을 사용하여 자막 생성 작업(Job)을 생성하는 메서드

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/config/VodRecommendBatchConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/config/VodRecommendBatchConfig.java
@@ -20,6 +20,8 @@ import org.springframework.transaction.PlatformTransactionManager;
 @Configuration
 @RequiredArgsConstructor
 public class VodRecommendBatchConfig {
+
+    private final FixedBackOffPolicy customBackOffPolicy;
     private final JobRepository jobRepository;
     private final PlatformTransactionManager tx;
 
@@ -48,14 +50,7 @@ public class VodRecommendBatchConfig {
                 .faultTolerant()
                 .retryLimit(3)
                 .retry(Exception.class)
-                .backOffPolicy(backOffPolicy())
+                .backOffPolicy(customBackOffPolicy)
                 .build();
-    }
-
-    @Bean
-    public FixedBackOffPolicy backOffPolicy() {
-        FixedBackOffPolicy policy = new FixedBackOffPolicy();
-        policy.setBackOffPeriod(2000L);
-        return policy;
     }
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/config/VodRecommendBatchConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/config/VodRecommendBatchConfig.java
@@ -1,0 +1,54 @@
+package com.ssginc.showpingrefactoring.batch.config;
+
+import com.ssginc.showpingrefactoring.batch.dto.VodRecommendDto;
+import com.ssginc.showpingrefactoring.batch.job.VodRecommendWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class VodRecommendBatchConfig {
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager tx;
+
+    private final JdbcPagingItemReader<VodRecommendDto> jdbcPagingReader;
+    private final VodRecommendWriter recommendWriter;
+
+    @Bean
+    public Job vodRecommendJob() {
+        return new JobBuilder("vodRecommendJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(vodRecommendStep())
+                .build();
+    }
+
+    @Bean
+    public Step vodRecommendStep() {
+        return new StepBuilder("vodRecommendStep", jobRepository)
+                .<VodRecommendDto, VodRecommendDto>chunk(500, tx)
+                .reader(jdbcPagingReader) // 필드로 주입받은 빈을 사용
+                .writer(recommendWriter)
+                .faultTolerant()
+                .retryLimit(3)
+                .retry(Exception.class)
+                .backOffPolicy(backOffPolicy())
+                .build();
+    }
+
+    @Bean
+    public FixedBackOffPolicy backOffPolicy() {
+        FixedBackOffPolicy policy = new FixedBackOffPolicy();
+        policy.setBackOffPeriod(2000L);
+        return policy;
+    }
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/config/VodRecommendBatchConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/config/VodRecommendBatchConfig.java
@@ -1,7 +1,9 @@
 package com.ssginc.showpingrefactoring.batch.config;
 
 import com.ssginc.showpingrefactoring.batch.dto.VodRecommendDto;
+import com.ssginc.showpingrefactoring.batch.job.VodRecommendProcessor;
 import com.ssginc.showpingrefactoring.batch.job.VodRecommendWriter;
+import com.ssginc.showpingrefactoring.batch.listener.JobFailureListener;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -23,12 +25,16 @@ public class VodRecommendBatchConfig {
 
     private final JdbcPagingItemReader<VodRecommendDto> jdbcPagingReader;
     private final VodRecommendWriter recommendWriter;
+    private final VodRecommendProcessor vodRecommendProcessor;
+
+    private final JobFailureListener jobFailureListener;
 
     @Bean
     public Job vodRecommendJob() {
         return new JobBuilder("vodRecommendJob", jobRepository)
                 .incrementer(new RunIdIncrementer())
                 .start(vodRecommendStep())
+                .listener(jobFailureListener)
                 .build();
     }
 
@@ -36,7 +42,8 @@ public class VodRecommendBatchConfig {
     public Step vodRecommendStep() {
         return new StepBuilder("vodRecommendStep", jobRepository)
                 .<VodRecommendDto, VodRecommendDto>chunk(500, tx)
-                .reader(jdbcPagingReader) // 필드로 주입받은 빈을 사용
+                .reader(jdbcPagingReader)
+                .processor(vodRecommendProcessor)
                 .writer(recommendWriter)
                 .faultTolerant()
                 .retryLimit(3)

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/dto/VodRecommendDto.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/dto/VodRecommendDto.java
@@ -1,0 +1,17 @@
+package com.ssginc.showpingrefactoring.batch.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VodRecommendDto {
+    private Integer ageGroup;
+    private String gender;
+    private Long streamNo;
+    private Long viewCount;
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/job/VodRecommendProcessor.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/job/VodRecommendProcessor.java
@@ -1,0 +1,18 @@
+package com.ssginc.showpingrefactoring.batch.job;
+
+import com.ssginc.showpingrefactoring.batch.dto.VodRecommendDto;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class VodRecommendProcessor implements ItemProcessor<VodRecommendDto, VodRecommendDto> {
+
+    @Override
+    public VodRecommendDto process(VodRecommendDto item) throws Exception {
+        // 테스트용: 강제로 에러 발생 시켜 슬랙 알림 확인
+//        if (true)
+//            throw new RuntimeException("슬랙 알림 테스트용 에러입니다!");
+
+        return item;
+    }
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/job/VodRecommendReader.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/job/VodRecommendReader.java
@@ -1,0 +1,68 @@
+package com.ssginc.showpingrefactoring.batch.job;
+
+import com.ssginc.showpingrefactoring.batch.dto.VodRecommendDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class VodRecommendReader {
+
+    private final DataSource dataSource;
+
+    @Bean
+    public JdbcPagingItemReader<VodRecommendDto> jdbcPagingReader() throws Exception {
+        return new JdbcPagingItemReaderBuilder<VodRecommendDto>()
+                .name("recommendReader")
+                .dataSource(dataSource)
+                .pageSize(500)
+                .rowMapper(new BeanPropertyRowMapper<>(VodRecommendDto.class))
+                .queryProvider(createQueryProvider())
+                .build();
+    }
+
+    private PagingQueryProvider createQueryProvider() throws Exception {
+        SqlPagingQueryProviderFactoryBean factory = new SqlPagingQueryProviderFactoryBean();
+        factory.setDataSource(dataSource);
+
+        // SELECT 절: 연령대 계산 로직
+        factory.setSelectClause("""
+            FLOOR(TIMESTAMPDIFF(YEAR, m.member_birthdate, CURDATE()) / 10) * 10 AS ageGroup,
+            m.member_gender AS gender,
+            w.stream_no AS streamNo,
+            COUNT(*) AS viewCount
+        """);
+
+        // FROM 절
+        factory.setFromClause("""
+            FROM watch w
+            JOIN member m ON w.member_no = m.member_no
+        """);
+
+        // 필터링 기준: 최근 7일 이내
+        factory.setWhereClause("w.watch_time >= DATE_SUB(NOW(), INTERVAL 7 DAYS)");
+
+        factory.setGroupClause("ageGroup, m.member_gender, w.stream_no");
+
+        // 정렬 설정 (PagingReader는 반드시 최소 한 개 이상의 정렬 키가 필요함)
+        // 여기서는 viewCount 내림차순을 위해 Map 활용
+        Map<String, Order> sortKeys = new HashMap<>();
+        sortKeys.put("ageGroup", Order.ASCENDING);
+        sortKeys.put("viewCount", Order.DESCENDING);
+        factory.setSortKeys(sortKeys);
+
+        return factory.getObject();
+    }
+
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/job/VodRecommendWriter.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/job/VodRecommendWriter.java
@@ -1,0 +1,29 @@
+package com.ssginc.showpingrefactoring.batch.job;
+
+import com.ssginc.showpingrefactoring.batch.dto.VodRecommendDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class VodRecommendWriter implements ItemWriter<VodRecommendDto> {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void write(Chunk<? extends VodRecommendDto> chunk) {
+        for (VodRecommendDto item : chunk) {
+            String key = String.format("recommend:age:%d:gender:%s", item.getAgeGroup(), item.getGender());
+
+            // Redis 저장 (score = viewCount)
+            redisTemplate.opsForZSet().add(key, String.valueOf(item.getStreamNo()), item.getViewCount());
+            redisTemplate.expire(key, 25, TimeUnit.HOURS);
+        }
+    }
+
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/listener/JobFailureListener.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/listener/JobFailureListener.java
@@ -1,0 +1,37 @@
+package com.ssginc.showpingrefactoring.batch.listener;
+
+import com.ssginc.showpingrefactoring.batch.service.SlackAlertService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JobFailureListener implements JobExecutionListener {
+
+    private final SlackAlertService slackAlertService; // 슬랙 서비스 주입
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        // 배치가 FAILED 상태로 종료된 경우에만 실행
+        if (jobExecution.getStatus() == BatchStatus.FAILED) {
+            String jobName = jobExecution.getJobInstance().getJobName();
+
+            String failedStep = jobExecution.getStepExecutions().stream()
+                    .filter(s -> s.getStatus() == BatchStatus.FAILED)
+                    .map(StepExecution::getStepName)
+                    .findFirst()
+                    .orElse("Unknown Step");
+
+            // 2. 예외 메시지에서 핵심 내용만 추출 (첫 줄만 가져오기)
+            String fullError = jobExecution.getExitStatus().getExitDescription();
+            String summaryError = fullError.split("\n")[0]; // 보통 첫 줄에 에러 타입과 메시지가 나옵니다.
+
+            // 슬랙 서비스 호출
+            slackAlertService.sendSlackAlert(jobName, failedStep);
+        }
+    }
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/scheduler/BatchScheduler.java
@@ -1,0 +1,29 @@
+package com.ssginc.showpingrefactoring.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job vodRecommendJob;
+
+    @Scheduled(cron = "0 0 12 * * *")
+    public void runJob() {
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("time", System.currentTimeMillis())
+                    .toJobParameters();
+            jobLauncher.run(vodRecommendJob, params);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/service/SlackAlertService.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/service/SlackAlertService.java
@@ -1,0 +1,52 @@
+package com.ssginc.showpingrefactoring.batch.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class SlackAlertService {
+
+    @Value("${slack.webhook.url}")
+    private String webhookUrl;
+
+    public void sendSlackAlert(String jobName, String stepName) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 1. 전체 메시지 구성
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("text", "⚠️ *배치 작업 중 예외가 발생했습니다.*");
+
+        // 2. 시각적 강조를 위한 Attachment 추가
+        Map<String, Object> attachment = new HashMap<>();
+        attachment.put("color", "#FF0000"); // 빨간색 바
+        attachment.put("ts", System.currentTimeMillis() / 1000); // 발생 시간 타임스탬프
+
+        // 3. 상세 내용을 필드 형태로 구성 (가독성 최적화)
+        List<Map<String, Object>> fields = new ArrayList<>();
+        fields.add(createField("실패 작업 (Job)", jobName, true));
+        fields.add(createField("실패 단계 (Step)", stepName, true));
+        fields.add(createField("발생 시각", LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")), true));
+        attachment.put("fields", fields);
+        payload.put("attachments", List.of(attachment));
+        try {
+            restTemplate.postForEntity(webhookUrl, payload, String.class);
+        } catch (Exception e) {
+            log.error("슬랙 메시지 전송 중 오류 발생: {}", e.getMessage());
+        }
+    }
+
+    private Map<String, Object> createField(String title, String value, boolean isShort) {
+        return Map.of("title", title, "value", value, "short", isShort);
+    }
+
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/util/CustomBackOffPolicy.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/util/CustomBackOffPolicy.java
@@ -1,0 +1,17 @@
+package com.ssginc.showpingrefactoring.batch.util;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+
+@Configuration
+public class CustomBackOffPolicy {
+
+    @Bean
+    public FixedBackOffPolicy customBackOffPolicy() {
+        FixedBackOffPolicy policy = new FixedBackOffPolicy();
+        policy.setBackOffPeriod(2000L);
+        return policy;
+    }
+
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/util/CustomBackOffPolicy.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/util/CustomBackOffPolicy.java
@@ -7,7 +7,7 @@ import org.springframework.retry.backoff.FixedBackOffPolicy;
 @Configuration
 public class CustomBackOffPolicy {
 
-    @Bean
+    @Bean(name = "CustomBackOffPolicy")
     public FixedBackOffPolicy customBackOffPolicy() {
         FixedBackOffPolicy policy = new FixedBackOffPolicy();
         policy.setBackOffPeriod(2000L);

--- a/src/main/java/com/ssginc/showpingrefactoring/batch/util/CustomRetryTemplate.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/batch/util/CustomRetryTemplate.java
@@ -1,0 +1,32 @@
+package com.ssginc.showpingrefactoring.batch.util;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+
+@Configuration
+public class CustomRetryTemplate {
+
+    @Bean(name = "CustomRetryTemplate")
+    RetryTemplate customRetryTemplate(@Qualifier("CustomBackOffPolicy") BackOffPolicy backOffPolicy) {
+        RetryTemplate retryTemplate = new RetryTemplate();
+
+        var retryPolicy = new SimpleRetryPolicy(
+                3, // max attempts
+                java.util.Map.of(
+                        java.net.SocketTimeoutException.class, true,
+                        org.springframework.web.client.HttpServerErrorException.class, true,
+                        org.springframework.dao.TransientDataAccessException.class, true
+                ),
+                true
+        );
+
+        retryTemplate.setRetryPolicy(retryPolicy);
+        retryTemplate.setBackOffPolicy(backOffPolicy);
+
+        return retryTemplate;
+    }
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/common/config/WebSocketConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/common/config/WebSocketConfig.java
@@ -6,6 +6,7 @@ import com.ssginc.showpingrefactoring.common.util.UserRegistry;
 import org.kurento.client.KurentoClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
@@ -19,6 +20,7 @@ import org.springframework.web.socket.server.standard.ServletServerContainerFact
  */
 @Configuration
 @EnableWebSocket
+@Profile("!test")
 public class WebSocketConfig implements WebSocketConfigurer {
 
     @Bean

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/member/entity/Member.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/member/entity/Member.java
@@ -12,6 +12,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -47,6 +48,12 @@ public class Member {
 
     @Column(name = "member_phone", length = 20, unique = true)
     private String memberPhone;
+
+    @Column(name = "member_gender", length = 10)
+    private String memberGender;
+
+    @Column(name = "member_birthdate")
+    private LocalDate memberBirthdate;
 
     @NotNull
     @Enumerated(EnumType.STRING)

--- a/src/test/java/com/ssginc/showpingrefactoring/batch/HlsJobTest.java
+++ b/src/test/java/com/ssginc/showpingrefactoring/batch/HlsJobTest.java
@@ -1,0 +1,96 @@
+package com.ssginc.showpingrefactoring.batch;
+
+import com.ssginc.showpingrefactoring.common.util.AesGcmCrypto;
+import com.ssginc.showpingrefactoring.domain.stream.service.HlsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.net.SocketTimeoutException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@SpringBatchTest
+@ActiveProfiles("test")
+@EnableAutoConfiguration(exclude = {
+        org.springframework.boot.autoconfigure.websocket.servlet.WebSocketServletAutoConfiguration.class,
+        org.springframework.boot.autoconfigure.websocket.servlet.WebSocketMessagingAutoConfiguration.class
+})
+public class HlsJobTest {
+
+    @MockBean(name = "aesGcmCrypto")
+    private AesGcmCrypto aesGcmCrypto;
+
+    @MockBean
+    private HlsService hlsService;
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    @Qualifier("createHlsJob")
+    private Job createHlsJob;
+
+    @BeforeEach
+    void setUp() {
+        jobLauncherTestUtils = new JobLauncherTestUtils();
+        jobLauncherTestUtils.setJobLauncher(jobLauncher);
+        jobLauncherTestUtils.setJobRepository(jobRepository);
+        jobLauncherTestUtils.setJob(createHlsJob);
+    }
+
+    @Test
+    void retry_then_success() throws Exception {
+        when(hlsService.createHLS("test-title"))
+                .thenThrow(new SocketTimeoutException("t1"))
+                .thenThrow(new SocketTimeoutException("t2"))
+                .thenReturn("hls-path-or-id");
+
+        JobParameters params = new JobParametersBuilder()
+                .addString("title", "test-title")
+                .addLong("run.id", System.currentTimeMillis()) // 파라미터 중복 방지
+                .toJobParameters();
+
+        JobExecution exec = jobLauncherTestUtils.launchJob(params);
+
+        assertThat(exec.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        verify(hlsService, times(3)).createHLS("test-title");
+    }
+
+    @Test
+    void retry_exhausted_then_fail() throws Exception {
+        // 3번 모두 실패
+        when(hlsService.createHLS("test-title"))
+                .thenThrow(new SocketTimeoutException("t1"))
+                .thenThrow(new SocketTimeoutException("t2"))
+                .thenThrow(new SocketTimeoutException("t3"));
+
+        JobParameters params = new JobParametersBuilder()
+                .addString("title", "test-title")
+                .addLong("run.id", System.currentTimeMillis())
+                .toJobParameters();
+
+        JobExecution exec = jobLauncherTestUtils.launchJob(params);
+
+        assertThat(exec.getStatus()).isEqualTo(BatchStatus.FAILED);
+        verify(hlsService, times(3)).createHLS("test-title");
+    }
+}


### PR DESCRIPTION
## 주요 내용
 - 연령별 및 성별 VOD 추천을 위한 데이터 파이프라인 구현 (최근 1주일 이내를 기준)
 - 수집된 데이터를 Redis에 저장 (유효기간은 25시간으로 설정)
 - 배치작업에 대한 Retry 구현 (2초 간격으로 실행 + 최대 3번까지 재시도)
 - 배치작업 최종 실패 시 Slack을 통한 알람 구현
***
## 추천 데이터 수집
 - WebBrowser
    - 형식은 StreamNo와 시청횟수를 표현
    - 테스트 데이터는 특정 연령대와 성별의 (ex: 50대 여성) 상위 10개 데이터를 추출
   <img width="1194" height="1484" alt="image" src="https://github.com/user-attachments/assets/dc2bc94a-f5b8-4b2c-8740-ef1f1bf7801b" />
***
## Slack 알람
 - 슬랙 설정 (Webhook URL 발급)
   - 슬랙 앱 생성: [Slack API Apps](https://api.slack.com/apps)에 접속하여 Create New App을 클릭
     - From scratch 선택 -> App Name(예: Batch-Alert-Bot) 입력 -> 적용할 Workspace 선택.
   - Webhook 활성화: 왼쪽 메뉴의 Incoming Webhooks를 클릭 후 상단의 스위치를 On으로 변경
   - Webhook 생성: 하단의 Add New Webhook to Workspace 버튼을 클릭
   - 채널 선택: 알림을 받을 채널(예: #server-alarm 등)을 선택하고 허용(Allow) 클릭
   - URL 복사 및 yml 적용: 생성된 Webhook URL을 복사하여 application.yml에 적용
    ``` yml
    slack:
       webhook:
        url: ${입력받은 url}
    ```
***
## 배치작업 실패 시 알람
  ![KakaoTalk_Photo_2026-02-27-17-24-03](https://github.com/user-attachments/assets/29685afd-17cf-4c38-9960-25fffc9c6359)
***
## 참고사항
 - 기존에 구현한 HLS 생성과 자막 생성과 관련해서도 배치작업 실패시 Retry와 Slack 알람을 구현하였습니다.
