### PR TITLE
Feat: 라이브 스트리밍 실시간 시청자 수 집계 및 UI 연동

### DIFF
--- a/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
@@ -251,6 +251,16 @@ public class LiveHandler extends TextWebSocketHandler {
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        String streamNo = (String) session.getAttributes().get("streamNo");
+
+        if (streamNo != null && viewers.containsKey(session.getId())) {
+            viewers.remove(session.getId());
+
+            liveService.decrementCount(streamNo);
+
+            log.info("시청자 퇴장: streamNo={}, sessionId={}", streamNo, session.getId());
+        }
+
         stop(session);
     }
 

--- a/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
@@ -93,11 +93,22 @@ public class LiveHandler extends TextWebSocketHandler {
         session.sendMessage(new TextMessage(response.toString()));
     }
 
-    private synchronized void presenter(final WebSocketSession session, JsonObject jsonMessage)
+    private void presenter(final WebSocketSession session, JsonObject jsonMessage)
             throws IOException {
-        if (presenterUserSession == null) {
-            presenterUserSession = new UserSession(session);
 
+        if (presenterUserSession != null) {
+            sendRejectedPresenterResponse(session);
+        }
+
+        synchronized (this) {
+            if (presenterUserSession != null) {
+                sendRejectedPresenterResponse(session);
+            }
+
+            presenterUserSession = new UserSession(session);
+        }
+
+        try {
             pipeline = kurento.createMediaPipeline();
             presenterUserSession.setWebRtcEndpoint(new WebRtcEndpoint.Builder(pipeline).build());
 
@@ -132,39 +143,33 @@ public class LiveHandler extends TextWebSocketHandler {
                 presenterUserSession.sendMessage(response);
             }
             presenterWebRtc.gatherCandidates();
-
-        } else {
-            JsonObject response = new JsonObject();
-            response.addProperty("id", "presenterResponse");
-            response.addProperty("response", "rejected");
-            response.addProperty("message",
-                    "Another user is currently acting as sender. Try again later ...");
-            session.sendMessage(new TextMessage(response.toString()));
+        } catch (Exception e) {
+            log.error("Presenter 설정 실패", e);
+            stop(session);
         }
     }
 
-    private synchronized void viewer(final WebSocketSession session, JsonObject jsonMessage)
+    private void viewer(final WebSocketSession session, JsonObject jsonMessage)
             throws IOException {
-        if (presenterUserSession == null || presenterUserSession.getWebRtcEndpoint() == null) {
+
+        UserSession presenter = presenterUserSession;
+        if (presenter == null || presenter.getWebRtcEndpoint() == null) {
             JsonObject response = new JsonObject();
             response.addProperty("id", "viewerResponse");
             response.addProperty("response", "rejected");
             response.addProperty("message",
                     "No active sender now. Become sender or . Try again later ...");
             session.sendMessage(new TextMessage(response.toString()));
-        } else {
-            if (viewers.containsKey(session.getId())) {
-                JsonObject response = new JsonObject();
-                response.addProperty("id", "viewerResponse");
-                response.addProperty("response", "rejected");
-                response.addProperty("message", "You are already viewing in this session. "
-                        + "Use a different browser to add additional viewers.");
-                session.sendMessage(new TextMessage(response.toString()));
-                return;
-            }
-            UserSession viewer = new UserSession(session);
-            viewers.put(session.getId(), viewer);
+        }
 
+        UserSession viewer = new UserSession(session);
+
+        if (viewers.putIfAbsent(session.getId(), viewer) != null) {
+            sendRejectedViewerResponse(session);
+            return;
+        }
+
+        try {
             WebRtcEndpoint nextWebRtc = new WebRtcEndpoint.Builder(pipeline).build();
 
             nextWebRtc.addIceCandidateFoundListener(new EventListener<IceCandidateFoundEvent>() {
@@ -185,7 +190,13 @@ public class LiveHandler extends TextWebSocketHandler {
             });
 
             viewer.setWebRtcEndpoint(nextWebRtc);
-            presenterUserSession.getWebRtcEndpoint().connect(nextWebRtc);
+
+            WebRtcEndpoint presenterWebRtc = presenter.getWebRtcEndpoint();
+            if (presenterWebRtc == null) {
+                throw new RuntimeException("Presenter endpoint disappeared.");
+            }
+            presenterWebRtc.connect(nextWebRtc);
+
             String sdpOffer = jsonMessage.getAsJsonPrimitive("sdpOffer").getAsString();
             String sdpAnswer = nextWebRtc.processOffer(sdpOffer);
 
@@ -198,6 +209,9 @@ public class LiveHandler extends TextWebSocketHandler {
                 viewer.sendMessage(response);
             }
             nextWebRtc.gatherCandidates();
+        } catch (Exception e) {
+            log.error("Viewer 연결 중 에러 발생", e);
+            stop(session);
         }
     }
 
@@ -228,4 +242,24 @@ public class LiveHandler extends TextWebSocketHandler {
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
         stop(session);
     }
+
+    private void sendRejectedPresenterResponse(WebSocketSession session) throws IOException {
+        JsonObject response = new JsonObject();
+        response.addProperty("id", "presenterResponse");
+        response.addProperty("response", "rejected");
+        response.addProperty("message",
+                "Another user is currently acting as sender. Try again later ...");
+        session.sendMessage(new TextMessage(response.toString()));
+    }
+
+    private void sendRejectedViewerResponse(WebSocketSession session) throws IOException {
+        JsonObject response = new JsonObject();
+        response.addProperty("id", "viewerResponse");
+        response.addProperty("response", "rejected");
+        response.addProperty("message", "You are already viewing in this session. "
+                + "Use a different browser to add additional viewers.");
+        session.sendMessage(new TextMessage(response.toString()));
+    }
+
 }
+

--- a/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
@@ -4,6 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.ssginc.showpingrefactoring.common.util.UserSession;
+import com.ssginc.showpingrefactoring.domain.stream.service.LiveService;
+import lombok.RequiredArgsConstructor;
 import org.kurento.client.*;
 import org.kurento.jsonrpc.JsonUtils;
 import org.slf4j.Logger;
@@ -33,6 +35,9 @@ public class LiveHandler extends TextWebSocketHandler {
 
     private MediaPipeline pipeline;
     private UserSession presenterUserSession;
+
+    @Autowired
+    private LiveService liveService;
 
     @Override
     public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
@@ -152,20 +157,23 @@ public class LiveHandler extends TextWebSocketHandler {
     private void viewer(final WebSocketSession session, JsonObject jsonMessage)
             throws IOException {
 
+        if (!jsonMessage.has("streamNo")) {
+            sendRejectedViewerResponse(session, "StreamNo is missing in message");
+            return;
+        }
+
+        String streamNo = jsonMessage.get("streamNo").getAsString();
+        session.getAttributes().put("streamNo", streamNo);
+
         UserSession presenter = presenterUserSession;
         if (presenter == null || presenter.getWebRtcEndpoint() == null) {
-            JsonObject response = new JsonObject();
-            response.addProperty("id", "viewerResponse");
-            response.addProperty("response", "rejected");
-            response.addProperty("message",
-                    "No active sender now. Become sender or . Try again later ...");
-            session.sendMessage(new TextMessage(response.toString()));
+            sendRejectedViewerResponse(session, "No active sender now. Become sender or . Try again later ...");
         }
 
         UserSession viewer = new UserSession(session);
 
         if (viewers.putIfAbsent(session.getId(), viewer) != null) {
-            sendRejectedViewerResponse(session);
+            sendRejectedViewerResponse(session, "You are already viewing in this session.");
             return;
         }
 
@@ -209,6 +217,9 @@ public class LiveHandler extends TextWebSocketHandler {
                 viewer.sendMessage(response);
             }
             nextWebRtc.gatherCandidates();
+
+            liveService.incrementCount(streamNo);
+
         } catch (Exception e) {
             log.error("Viewer 연결 중 에러 발생", e);
             stop(session);
@@ -252,12 +263,11 @@ public class LiveHandler extends TextWebSocketHandler {
         session.sendMessage(new TextMessage(response.toString()));
     }
 
-    private void sendRejectedViewerResponse(WebSocketSession session) throws IOException {
+    private void sendRejectedViewerResponse(WebSocketSession session, String message) throws IOException {
         JsonObject response = new JsonObject();
         response.addProperty("id", "viewerResponse");
         response.addProperty("response", "rejected");
-        response.addProperty("message", "You are already viewing in this session. "
-                + "Use a different browser to add additional viewers.");
+        response.addProperty("message", message);
         session.sendMessage(new TextMessage(response.toString()));
     }
 

--- a/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.ssginc.showpingrefactoring.common.util.UserSession;
 import com.ssginc.showpingrefactoring.domain.stream.service.LiveService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.kurento.client.*;
 import org.kurento.jsonrpc.JsonUtils;
@@ -28,6 +29,7 @@ public class LiveHandler extends TextWebSocketHandler {
     private static final Logger log = LoggerFactory.getLogger(LiveHandler.class);
     private static final Gson gson = new GsonBuilder().create();
 
+    @Getter
     private final ConcurrentHashMap<String, UserSession> viewers = new ConcurrentHashMap<>();
 
     @Autowired
@@ -38,6 +40,7 @@ public class LiveHandler extends TextWebSocketHandler {
 
     @Autowired
     private LiveService liveService;
+
 
     @Override
     public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
@@ -1,0 +1,65 @@
+package com.ssginc.showpingrefactoring.domain.stream.scheduler;
+
+import com.google.gson.JsonObject;
+import com.ssginc.showpingrefactoring.common.handler.LiveHandler;
+import com.ssginc.showpingrefactoring.common.util.UserSession;
+import com.ssginc.showpingrefactoring.domain.stream.service.LiveService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LiveStatsScheduler {
+
+    private final LiveService liveService;
+    private final LiveHandler liveHandler;
+
+    @Scheduled(fixedRate = 5000)
+    public void broadCastLiveStats() {
+        ConcurrentHashMap<String, UserSession> currentViewers = liveHandler.getViewers();
+
+        if (currentViewers.isEmpty()) return;
+
+        // streamNo별로 인원수 집계
+        Map<String, Long> statsByStream = currentViewers.values().stream()
+                .map(userSession -> (String) userSession.getSession().getAttributes().get("streamNo"))
+                .filter(Objects::nonNull)
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+        // 각 streamNo별로 처리
+        statsByStream.forEach((streamNo, count) -> {
+            liveService.saveSnapshot(streamNo, count.intValue());
+
+            // 3. 해당 streamNo를 보고 있는 시청자들에게만 메시지 전송
+            JsonObject countMessage = new JsonObject();
+            countMessage.addProperty("id", "viewerCountUpdate");
+            countMessage.addProperty("count", count);
+
+            currentViewers.values().stream()
+                    .filter(user -> streamNo.equals(user.getSession().getAttributes().get("streamNo")))
+                    .forEach(user -> {
+                        try {
+                            synchronized (user.getSession()) {
+                                if (user.getSession().isOpen()) {
+                                    user.sendMessage(countMessage);
+                                }
+                            }
+                        } catch (IOException e) {
+                            log.error("인원수 전송 에러: {}", e.getMessage());
+                        }
+                    });
+        });
+
+    }
+
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
@@ -29,4 +29,5 @@ public interface LiveService {
 
     void incrementCount(String streamNo);
 
+    void decrementCount(String streamNo);
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
@@ -27,4 +27,6 @@ public interface LiveService {
 
     GetLiveRegisterInfoResponseDto getLiveRegisterInfo(String memberId);
 
+    void incrementCount(String streamNo);
+
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
@@ -30,4 +30,7 @@ public interface LiveService {
     void incrementCount(String streamNo);
 
     void decrementCount(String streamNo);
+
+    void saveSnapshot(String streamNo, int viewerCount);
+
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.text.NumberFormat;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -43,9 +44,7 @@ public class LiveServiceImpl implements LiveService {
 
     private final StringRedisTemplate redisTemplate;
 
-    private static final String COUNT_KEY_PREFIX = "live:count:";
-
-    private static final String STATS_KEY_PREFIX = "stats:";
+    private static final String COUNT_KEY_PREFIX = "live:streamNo:";
 
     /**
      * 시청하려는 방송의 상품을 정보를 가져오는 메서드
@@ -265,14 +264,25 @@ public class LiveServiceImpl implements LiveService {
 
     @Override
     public void incrementCount(String streamNo) {
-        String key = COUNT_KEY_PREFIX + streamNo;
+        String key = COUNT_KEY_PREFIX + streamNo + ":count:";
         redisTemplate.opsForValue().increment(key);
     }
 
     @Override
     public void decrementCount(String streamNo) {
-        String key = COUNT_KEY_PREFIX + streamNo;
+        String key = COUNT_KEY_PREFIX + streamNo + ":count:";
         redisTemplate.opsForValue().decrement(key);
+    }
+
+    @Override
+    public void saveSnapshot(String streamNo, int viewerCount) {
+        long timestamp = System.currentTimeMillis() / 1000;
+        String key = "stats:" + streamNo;
+        String data = timestamp + ":" + viewerCount;
+
+        redisTemplate.opsForZSet().add(key, data, (double) timestamp);
+
+        redisTemplate.expire(key, Duration.ofHours(24));
     }
 
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
@@ -266,10 +266,13 @@ public class LiveServiceImpl implements LiveService {
     @Override
     public void incrementCount(String streamNo) {
         String key = COUNT_KEY_PREFIX + streamNo;
-
         redisTemplate.opsForValue().increment(key);
+    }
 
-        System.out.println("시청수 증가 발생 " + redisTemplate.opsForValue().get(key) + "명");
+    @Override
+    public void decrementCount(String streamNo) {
+        String key = COUNT_KEY_PREFIX + streamNo;
+        redisTemplate.opsForValue().decrement(key);
     }
 
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.text.NumberFormat;
@@ -39,6 +40,12 @@ public class LiveServiceImpl implements LiveService {
     private final ProductRepository productRepository;
 
     private final MemberRepository memberRepository;
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String COUNT_KEY_PREFIX = "live:count:";
+
+    private static final String STATS_KEY_PREFIX = "stats:";
 
     /**
      * 시청하려는 방송의 상품을 정보를 가져오는 메서드
@@ -254,6 +261,15 @@ public class LiveServiceImpl implements LiveService {
             return null;
         }
 
+    }
+
+    @Override
+    public void incrementCount(String streamNo) {
+        String key = COUNT_KEY_PREFIX + streamNo;
+
+        redisTemplate.opsForValue().increment(key);
+
+        System.out.println("시청수 증가 발생 " + redisTemplate.opsForValue().get(key) + "명");
     }
 
 }

--- a/src/main/resources/static/css/watch/stream.css
+++ b/src/main/resources/static/css/watch/stream.css
@@ -34,6 +34,51 @@
     padding-top: 15px;
 }
 
+.live-container {
+    position: relative; /* 자식 요소인 badge의 기준점이 됨 */
+    width: 100%;
+    max-width: 300px; /* 원하는 너비 설정 */
+    max-height: 480px;
+    aspect-ratio: 9 / 16; /* 세로형 라이브일 경우 */
+    background-color: #000;
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+/* 시청자 수 배지 스타일 */
+.viewer-badge {
+    position: absolute; /* 컨테이너 내부에서 자유롭게 배치 */
+    top: 20px;         /* 상단에서 20px 띄움 */
+    left: 20px;        /* 왼쪽에서 20px 띄움 */
+
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    padding: 6px 12px;
+    background-color: rgba(0, 0, 0, 0.6); /* 반투명 검정 */
+    color: white;
+    border-radius: 20px;
+    font-size: 14px;
+    font-weight: 500;
+    z-index: 10; /* 영상보다 위에 보이도록 */
+}
+
+@keyframes blink {
+    0% { opacity: 1; }
+    50% { opacity: 0.3; }
+    100% { opacity: 1; }
+}
+
+.live-text {
+    color: #ff4d4d;
+    font-weight: bold;
+}
+
+.divider {
+    color: rgba(255, 255, 255, 0.3);
+}
+
 .vod-container {
     width: 300px;
 }

--- a/src/main/resources/static/js/stream/stream.js
+++ b/src/main/resources/static/js/stream/stream.js
@@ -263,6 +263,9 @@ ws.onmessage = function(message) {
                     return console.error('Error adding candidate: ' + error);
             });
             break;
+        case 'viewerCountUpdate':
+            updateViewerCount(parsedMessage.count);
+            break;
         case 'stopCommunication':
             dispose();
             break;
@@ -330,6 +333,22 @@ function viewerResponse(message) {
         });
     }
     connectToChatRoom();
+}
+
+function updateViewerCount(count) {
+    const countElement = document.getElementById('viewer-count');
+    if (!countElement) return;
+
+    let displayCount;
+    if (count >= 1000000) {
+        displayCount = (count / 1000000).toFixed(1) + 'M'; // 1.1M
+    } else if (count >= 1000) {
+        displayCount = (count / 1000).toFixed(1) + 'K'; // 1.2K
+    } else {
+        displayCount = count; // 999 이하일 땐 숫자 그대로
+    }
+
+    countElement.textContent = displayCount;
 }
 
 async function startLive() {

--- a/src/main/resources/static/js/stream/stream.js
+++ b/src/main/resources/static/js/stream/stream.js
@@ -432,8 +432,13 @@ function onLiveOffer(error, offerSdp) {
 function onViewOffer(error, offerSdp) {
     if (error)
         return console.error('Error generating the offer');
+
+    const pathSegments = window.location.pathname.split('/');
+    const streamNo = pathSegments[pathSegments.length - 1];
+
     var message = {
         id : 'viewer',
+        streamNo: streamNo,
         sdpOffer : offerSdp
     }
     sendLiveMessage(message);

--- a/src/main/resources/templates/stream/watch.html
+++ b/src/main/resources/templates/stream/watch.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" th:href="@{/webjars/ekko-lightbox/5.2.0/dist/ekko-lightbox.css}">
     <link rel="shortcut icon" th:href="@{/img/kurento.png}" type="image/png"/>
     <link rel="stylesheet" th:href="@{https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css}">
-    
+    <link rel="stylesheet" th:href="@{https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css}">
     
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script th:src="@{/webjars/jquery/3.7.1/dist/jquery.js}"></script>
@@ -35,6 +35,12 @@
                 <div class="video">
                     <video id="live" autoplay playsinline>
                     </video>
+
+                    <div class="viewer-badge">
+                        <i class="fa-regular fa-user"></i>
+                        <span id="viewer-count">0</span>
+                    </div>
+
                 </div>
             </div>
             <div class="chat-container">


### PR DESCRIPTION
## 작업 개요
 - 라이브 방송 접속 시 `streamNo` 기반으로 실시간 시청자 수 집계
 -  브로드캐스트하여 UI에 반영하는 기능 구현
 -  추후 하이라이트 분석을 위한 시청자 수 스냅샷을 Redis ZSET에 저장하는 로직 구현
---

## 주요 변경 사항
### 1. Backend (Spring Boot & Redis)
* **`LiveStreamService`**: 
    * Redis `INCR/DECR` 명령어를 사용하여 원자적인 시청자 수 증감 구현
    * `saveSnapshot`: 하이라이트 분석용 시계열 데이터(ZSET) 저장 로직 구현
* **`LiveHandler` (WebSocket)**:
    * `viewer` 진입 시 URL에서 추출된 `streamNo`를 세션 속성에 저장 및 카운트 증가
    * `afterConnectionClosed`: 세션 종료 시 자동으로 해당 방송의 카운트 감소 처리
* **`LiveStatsScheduler`**:
    * 5초 주기로 메모리(`ConcurrentHashMap`)의 실제 접속자 수를 집계하여 Redis 데이터 정합성 보정 및 클라이언트 브로드캐스트 실행.
### 2. Frontend (JavaScript & CSS)
* **`stream.js`**: 
    * `onViewOffer`: 서버로 `viewer` 메시지 전송 시 `streamNo` 포함
    * `ws.onmessage`: 서버의 `viewerCountUpdate` 이벤트를 수신하여 UI 갱신
* **UI/UX**: 
    * 비디오 컨테이너 내 좌상단에 `position: absolute`를 활용한 실시간 시청자 수 배지 구현
---
## 주요 이슈
 * Redis : 다중 서버 환경에서도 전체 방송의 시청자 수를 통합 관리하기 위해 In-memory DB인 Redis를 선택
 * 정합성 유지 전략: `INCR/DECR`만으로 소켓 유실 시 오차가 발생할 수 있습니다. 이를 해결하기 위해 `Scheduler`가 5초마다 실제 세션 맵(`viewers`)의 크기를 측정하여 Redis 값을 강제 동기화(Sync)하도록 설계했습니다.
---