### PR TITLE
Refactor: 라이브 시청자 집계 시스템 리팩토링

### DIFF
--- a/src/main/java/com/ssginc/showpingrefactoring/common/config/SchedulerConfig.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/common/config/SchedulerConfig.java
@@ -1,0 +1,22 @@
+package com.ssginc.showpingrefactoring.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        scheduler.setThreadNamePrefix("live-schedule-");
+        scheduler.initialize();
+        return scheduler;
+    }
+
+}

--- a/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
@@ -31,11 +31,14 @@ public class LiveHandler extends TextWebSocketHandler {
     @Getter
     private final ConcurrentHashMap<String, UserSession> viewers = new ConcurrentHashMap<>();
 
+    @Getter
+    private UserSession presenterUserSession;
+
     @Autowired
     private KurentoClient kurento;
 
     private MediaPipeline pipeline;
-    private UserSession presenterUserSession;
+
 
     @Autowired
     private LiveService liveService;
@@ -106,6 +109,14 @@ public class LiveHandler extends TextWebSocketHandler {
         if (presenterUserSession != null) {
             sendRejectedPresenterResponse(session);
         }
+
+        if (!jsonMessage.has("streamNo")) {
+            sendRejectedPresenterResponse(session);
+            return;
+        }
+
+        String streamNo = jsonMessage.get("streamNo").getAsString();
+        session.getAttributes().put("streamNo", streamNo);
 
         synchronized (this) {
             if (presenterUserSession != null) {

--- a/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/common/handler/LiveHandler.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import com.ssginc.showpingrefactoring.common.util.UserSession;
 import com.ssginc.showpingrefactoring.domain.stream.service.LiveService;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.kurento.client.*;
 import org.kurento.jsonrpc.JsonUtils;
 import org.slf4j.Logger;

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/controller/LiveApiController.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/controller/LiveApiController.java
@@ -2,7 +2,6 @@ package com.ssginc.showpingrefactoring.domain.stream.controller;
 
 import com.ssginc.showpingrefactoring.domain.product.dto.response.GetProductListResponseDto;
 import com.ssginc.showpingrefactoring.domain.product.service.ProductService;
-import com.ssginc.showpingrefactoring.domain.product.dto.object.ProductItemDto;
 import com.ssginc.showpingrefactoring.domain.stream.dto.request.RegisterLiveRequestDto;
 import com.ssginc.showpingrefactoring.domain.stream.dto.request.LiveRequestDto;
 import com.ssginc.showpingrefactoring.domain.stream.dto.response.GetLiveRegisterInfoResponseDto;

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/controller/LiveApiController.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/controller/LiveApiController.java
@@ -8,6 +8,7 @@ import com.ssginc.showpingrefactoring.domain.stream.dto.request.LiveRequestDto;
 import com.ssginc.showpingrefactoring.domain.stream.dto.response.GetLiveRegisterInfoResponseDto;
 import com.ssginc.showpingrefactoring.domain.stream.dto.response.StartLiveResponseDto;
 import com.ssginc.showpingrefactoring.domain.stream.dto.response.StreamResponseDto;
+import com.ssginc.showpingrefactoring.domain.stream.scheduler.LiveStatsScheduler;
 import com.ssginc.showpingrefactoring.domain.stream.service.LiveService;
 import com.ssginc.showpingrefactoring.domain.stream.swagger.LiveApiSpecification;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,8 @@ public class LiveApiController implements LiveApiSpecification {
     private final LiveService liveService;
 
     private final ProductService productService;
+
+    private final LiveStatsScheduler liveStatsScheduler;
 
     /**
      * 라이브 방송을 반환해주는 컨트롤러 메서드
@@ -150,6 +153,8 @@ public class LiveApiController implements LiveApiSpecification {
     public ResponseEntity<StartLiveResponseDto> startLive(@RequestBody LiveRequestDto request) {
         StartLiveResponseDto response = liveService.startLive(request.getStreamNo());
 
+        liveStatsScheduler.startViewCountScheduler(request.getStreamNo());
+
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
@@ -162,6 +167,8 @@ public class LiveApiController implements LiveApiSpecification {
     @Override
     public ResponseEntity<Map<String, Boolean>> stopLive(@RequestBody LiveRequestDto request) {
         Boolean result = liveService.stopLive(request.getStreamNo());
+
+        liveStatsScheduler.stopViewCountScheduler(request.getStreamNo());
 
         Map<String, Boolean> response = new HashMap<>();
         response.put("result", result);

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/controller/LiveApiController.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/controller/LiveApiController.java
@@ -187,4 +187,12 @@ public class LiveApiController implements LiveApiSpecification {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+
+    @GetMapping("/viewCount/{streamNo}")
+    public ResponseEntity<?> getViewCount(@PathVariable Long streamNo) {
+        Long viewCount = liveService.getViewCount(streamNo);
+
+        return ResponseEntity.status(HttpStatus.OK).body(viewCount);
+    }
+
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
@@ -73,12 +73,12 @@ public class LiveStatsScheduler {
 
         // 메시지 전송
         if (isSameStream(currentPresenter, streamNo)) {
-            sendMessageSafe(currentPresenter, countMessage, streamNo);
+            sendMessage(currentPresenter, countMessage, streamNo);
         }
 
         currentViewers.values().stream()
                 .filter(user -> isSameStream(user, streamNo))
-                .forEach(user -> sendMessageSafe(user, countMessage, streamNo));
+                .forEach(user -> sendMessage(user, countMessage, streamNo));
 
     }
 
@@ -88,7 +88,7 @@ public class LiveStatsScheduler {
         return attr != null && streamNo.equals(Long.valueOf(attr.toString()));
     }
 
-    private void sendMessageSafe(UserSession user, JsonObject message, Long streamNo) {
+    private void sendMessage(UserSession user, JsonObject message, Long streamNo) {
         try {
             synchronized (user.getSession()) {
                 if (user.getSession().isOpen()) {

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
@@ -6,6 +6,7 @@ import com.ssginc.showpingrefactoring.common.util.UserSession;
 import com.ssginc.showpingrefactoring.domain.stream.service.LiveService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@EnableScheduling
 public class LiveStatsScheduler {
 
     private final LiveService liveService;

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
@@ -52,6 +52,7 @@ public class LiveStatsScheduler {
     }
 
     private void broadcastViewCountByStream(Long streamNo) {
+        UserSession currentPresenter = liveHandler.getPresenterUserSession();
         ConcurrentHashMap<String, UserSession> currentViewers = liveHandler.getViewers();
 
         // 해당 streamNo를 보고 있는 유저 필터링 (Long 비교)
@@ -71,22 +72,33 @@ public class LiveStatsScheduler {
         countMessage.addProperty("count", count);
 
         // 메시지 전송
+        if (isSameStream(currentPresenter, streamNo)) {
+            sendMessageSafe(currentPresenter, countMessage, streamNo);
+        }
+
         currentViewers.values().stream()
-                .filter(user -> {
-                    Object attr = user.getSession().getAttributes().get("streamNo");
-                    return attr != null && streamNo.equals(Long.valueOf(attr.toString()));
-                })
-                .forEach(user -> {
-                    try {
-                        synchronized (user.getSession()) {
-                            if (user.getSession().isOpen()) {
-                                user.sendMessage(countMessage);
-                            }
-                        }
-                    } catch (IOException e) {
-                        log.error("전송 에러 [streamNo: {}]: {}", streamNo, e.getMessage());
-                    }
-                });
+                .filter(user -> isSameStream(user, streamNo))
+                .forEach(user -> sendMessageSafe(user, countMessage, streamNo));
+
+    }
+
+    private boolean isSameStream(UserSession user, Long streamNo) {
+        if (user == null || user.getSession() == null) return false;
+        Object attr = user.getSession().getAttributes().get("streamNo");
+        return attr != null && streamNo.equals(Long.valueOf(attr.toString()));
+    }
+
+    private void sendMessageSafe(UserSession user, JsonObject message, Long streamNo) {
+        try {
+            synchronized (user.getSession()) {
+                if (user.getSession().isOpen()) {
+                    user.sendMessage(message);
+                }
+            }
+        } catch (IOException e) {
+            log.error("메시지 전송 실패 [streamNo: {}, sessionId: {}]: {}",
+                    streamNo, user.getSession().getId(), e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
@@ -6,62 +6,90 @@ import com.ssginc.showpingrefactoring.common.util.UserSession;
 import com.ssginc.showpingrefactoring.domain.stream.service.LiveService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
-@EnableScheduling
 public class LiveStatsScheduler {
 
+    private final TaskScheduler taskScheduler;
+
     private final LiveService liveService;
+
     private final LiveHandler liveHandler;
 
-    @Scheduled(fixedRate = 5000)
-    public void broadCastLiveStats() {
+    private final Map<Long, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+
+    public void startViewCountScheduler(Long streamNo) {
+        if (scheduledTasks.containsKey(streamNo)) {
+            log.warn("이미 스케줄러가 동작 중인 방송입니다. streamNo: {}", streamNo);
+            return;
+        }
+
+        // 5초마다 해당 streamNo에 대해서만 실행
+        ScheduledFuture<?> task = taskScheduler.scheduleAtFixedRate(() -> {
+            broadcastViewCountByStream(streamNo);
+        }, 3000);
+
+        scheduledTasks.put(streamNo, task);
+        log.info("라이브 스케줄러 시작 [streamNo: {}]", streamNo);
+    }
+
+    public void stopViewCountScheduler(Long streamNo) {
+        ScheduledFuture<?> task = scheduledTasks.get(streamNo);
+        if (task != null) {
+            task.cancel(false);
+            scheduledTasks.remove(streamNo);
+            log.info("라이브 스케줄러 중단 [streamNo: {}]", streamNo);
+        }
+    }
+
+    private void broadcastViewCountByStream(Long streamNo) {
         ConcurrentHashMap<String, UserSession> currentViewers = liveHandler.getViewers();
 
-        if (currentViewers.isEmpty()) return;
+        // 해당 streamNo를 보고 있는 유저 필터링 (Long 비교)
+        long count = currentViewers.values().stream()
+                .filter(user -> {
+                    Object attr = user.getSession().getAttributes().get("streamNo");
+                    return attr != null && streamNo.equals(Long.valueOf(attr.toString()));
+                })
+                .count();
 
-        // streamNo별로 인원수 집계
-        Map<String, Long> statsByStream = currentViewers.values().stream()
-                .map(userSession -> (String) userSession.getSession().getAttributes().get("streamNo"))
-                .filter(Objects::nonNull)
-                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        // DB 저장 (Long 타입 streamNo 전달)
+        liveService.saveSnapshot(streamNo, (int) count);
 
-        // 각 streamNo별로 처리
-        statsByStream.forEach((streamNo, count) -> {
-            liveService.saveSnapshot(streamNo, count.intValue());
+        // 메시지 구성
+        JsonObject countMessage = new JsonObject();
+        countMessage.addProperty("id", "viewerCountUpdate");
+        countMessage.addProperty("count", count);
 
-            // 3. 해당 streamNo를 보고 있는 시청자들에게만 메시지 전송
-            JsonObject countMessage = new JsonObject();
-            countMessage.addProperty("id", "viewerCountUpdate");
-            countMessage.addProperty("count", count);
-
-            currentViewers.values().stream()
-                    .filter(user -> streamNo.equals(user.getSession().getAttributes().get("streamNo")))
-                    .forEach(user -> {
-                        try {
-                            synchronized (user.getSession()) {
-                                if (user.getSession().isOpen()) {
-                                    user.sendMessage(countMessage);
-                                }
+        // 메시지 전송
+        currentViewers.values().stream()
+                .filter(user -> {
+                    Object attr = user.getSession().getAttributes().get("streamNo");
+                    return attr != null && streamNo.equals(Long.valueOf(attr.toString()));
+                })
+                .forEach(user -> {
+                    try {
+                        synchronized (user.getSession()) {
+                            if (user.getSession().isOpen()) {
+                                user.sendMessage(countMessage);
                             }
-                        } catch (IOException e) {
-                            log.error("인원수 전송 에러: {}", e.getMessage());
                         }
-                    });
-        });
-
+                    } catch (IOException e) {
+                        log.error("전송 에러 [streamNo: {}]: {}", streamNo, e.getMessage());
+                    }
+                });
     }
 
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/scheduler/LiveStatsScheduler.java
@@ -11,11 +11,8 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
@@ -31,7 +31,7 @@ public interface LiveService {
 
     void decrementCount(String streamNo);
 
-    void saveSnapshot(String streamNo, int viewerCount);
+    void saveSnapshot(Long streamNo, int viewerCount);
 
     Long getViewCount(Long streamNo);
 

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/LiveService.java
@@ -33,4 +33,6 @@ public interface LiveService {
 
     void saveSnapshot(String streamNo, int viewerCount);
 
+    Long getViewCount(Long streamNo);
+
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
@@ -278,7 +278,7 @@ public class LiveServiceImpl implements LiveService {
     }
 
     @Override
-    public void saveSnapshot(String streamNo, int viewerCount) {
+    public void saveSnapshot(Long streamNo, int viewerCount) {
         long timestamp = System.currentTimeMillis() / 1000;
         String key = "stats:" + streamNo;
         String data = timestamp + ":" + viewerCount;

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
@@ -2,6 +2,8 @@ package com.ssginc.showpingrefactoring.domain.stream.service.implement;
 
 import com.ssginc.showpingrefactoring.common.exception.CustomException;
 import com.ssginc.showpingrefactoring.common.exception.ErrorCode;
+import com.ssginc.showpingrefactoring.common.handler.LiveHandler;
+import com.ssginc.showpingrefactoring.common.util.UserSession;
 import com.ssginc.showpingrefactoring.domain.member.entity.Member;
 import com.ssginc.showpingrefactoring.domain.member.repository.MemberRepository;
 import com.ssginc.showpingrefactoring.domain.product.repository.ProductRepository;
@@ -30,6 +32,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Service
@@ -283,6 +286,14 @@ public class LiveServiceImpl implements LiveService {
         redisTemplate.opsForZSet().add(key, data, (double) timestamp);
 
         redisTemplate.expire(key, Duration.ofHours(24));
+    }
+
+    @Override
+    public Long getViewCount(Long streamNo) {
+        String key = COUNT_KEY_PREFIX + streamNo + ":count:";
+        String value = redisTemplate.opsForValue().get(key);
+
+        return value == null ? null : Long.parseLong(value);
     }
 
 }

--- a/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
+++ b/src/main/java/com/ssginc/showpingrefactoring/domain/stream/service/implement/LiveServiceImpl.java
@@ -2,8 +2,6 @@ package com.ssginc.showpingrefactoring.domain.stream.service.implement;
 
 import com.ssginc.showpingrefactoring.common.exception.CustomException;
 import com.ssginc.showpingrefactoring.common.exception.ErrorCode;
-import com.ssginc.showpingrefactoring.common.handler.LiveHandler;
-import com.ssginc.showpingrefactoring.common.util.UserSession;
 import com.ssginc.showpingrefactoring.domain.member.entity.Member;
 import com.ssginc.showpingrefactoring.domain.member.repository.MemberRepository;
 import com.ssginc.showpingrefactoring.domain.product.repository.ProductRepository;
@@ -32,7 +30,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Service

--- a/src/main/resources/static/js/stream/stream.js
+++ b/src/main/resources/static/js/stream/stream.js
@@ -24,6 +24,10 @@ document.addEventListener('DOMContentLoaded', function () {
         live = document.getElementById('live-video');
         watch = document.getElementById('live');
 
+        if (watch) {
+            initViewerCount();
+        }
+
         if (live) {
             getMemberInfo(); // 여기서 memberRole을 설정함
 
@@ -38,8 +42,6 @@ document.addEventListener('DOMContentLoaded', function () {
             }, 100);
 
         }
-
-        initViewerCount();
         getMemberInfo();
 
         // send 버튼 이벤트와 STOMP 연결 초기화
@@ -305,7 +307,6 @@ rec.onmessage = function(message) {
 
 function presenterResponse(message) {
     setState(IN_CALL);
-    console.log('SDP answer received from server. Processing ...');
 
     webRtcPeer.processAnswer(message.sdpAnswer, function(error) {
         if (error) {
@@ -316,7 +317,6 @@ function presenterResponse(message) {
 }
 
 function startResponse(message) {
-    console.log('SDP answer received from server. Processing ...');
     webRtcRecord.processAnswer(message.sdpAnswer, function(error) {
         if (error)
             return console.error(error);
@@ -346,6 +346,8 @@ function initViewerCount() {
 }
 
 function updateViewerCount(count) {
+    console.log("시청자 수 집계 업데이트");
+
     const countElement = document.getElementById('viewer-count');
     if (!countElement) return;
 
@@ -416,8 +418,6 @@ function viewer() {
 }
 
 function onLiveIceCandidate(candidate) {
-    console.log("Local candidate" + JSON.stringify(candidate));
-
     let message = {
         id : 'onIceCandidate',
         candidate : candidate
@@ -426,7 +426,6 @@ function onLiveIceCandidate(candidate) {
 }
 
 function createVideo() {
-
     let options = {
         localVideo : live,
         mediaConstraints : getConstraints(),
@@ -454,6 +453,7 @@ function onLiveOffer(error, offerSdp) {
         return console.error('Error generating the offer');
     let message = {
         id : 'presenter',
+        streamNo: streamNo,
         sdpOffer : offerSdp
     }
     sendLiveMessage(message);
@@ -462,9 +462,6 @@ function onLiveOffer(error, offerSdp) {
 function onViewOffer(error, offerSdp) {
     if (error)
         return console.error('Error generating the offer');
-
-    const pathSegments = window.location.pathname.split('/');
-    const streamNo = pathSegments[pathSegments.length - 1];
 
     var message = {
         id : 'viewer',
@@ -479,7 +476,7 @@ function onRecordOffer(error, offerSdp) {
 
     if (error)
         return console.error('Error generating the offer');
-    console.info('Invoking SDP offer callback function ' + location.host);
+
     let message = {
         id : 'start',
         title: title,

--- a/src/main/resources/static/js/stream/stream.js
+++ b/src/main/resources/static/js/stream/stream.js
@@ -338,9 +338,11 @@ function viewerResponse(message) {
 }
 
 function initViewerCount() {
-    const countElement = document.getElementById('viewer-count');
-
-    viewerCount = countElement.textContent;
+    axios.get(`/api/live/viewCount/${streamNo}`)
+        .then(response => {
+            updateViewerCount(response.data);
+            }
+        )
 }
 
 function updateViewerCount(count) {

--- a/src/main/resources/static/js/stream/stream.js
+++ b/src/main/resources/static/js/stream/stream.js
@@ -11,6 +11,7 @@ let stompClient = null;
 let memberId = null;
 let memberRole = null;
 let reconnectTimeout = 5000;
+let viewerCount = null;
 
 const NO_CALL = 0;
 const IN_CALL = 1;
@@ -38,6 +39,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         }
 
+        initViewerCount();
         getMemberInfo();
 
         // send 버튼 이벤트와 STOMP 연결 초기화
@@ -335,6 +337,12 @@ function viewerResponse(message) {
     connectToChatRoom();
 }
 
+function initViewerCount() {
+    const countElement = document.getElementById('viewer-count');
+
+    viewerCount = countElement.textContent;
+}
+
 function updateViewerCount(count) {
     const countElement = document.getElementById('viewer-count');
     if (!countElement) return;
@@ -349,6 +357,7 @@ function updateViewerCount(count) {
     }
 
     countElement.textContent = displayCount;
+    viewerCount = displayCount;
 }
 
 async function startLive() {

--- a/src/main/resources/templates/stream/stream.html
+++ b/src/main/resources/templates/stream/stream.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" th:href="@{/webjars/ekko-lightbox/5.2.0/dist/ekko-lightbox.css}">
     <link rel="shortcut icon" th:href="@{/img/kurento.png}" type="image/png"/>
     <link rel="stylesheet" th:href="@{https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css}">
-    
+    <link rel="stylesheet" th:href="@{https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css}">
     
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script th:src="@{/webjars/jquery/3.7.1/dist/jquery.js}"></script>
@@ -38,6 +38,12 @@
                 <div class="video">
                     <video id="live-video" autoplay playsinline>
                     </video>
+
+                    <div class="viewer-badge">
+                        <i class="fa-regular fa-user"></i>
+                        <span id="viewer-count">0</span>
+                    </div>
+
                 </div>
             </div>
             <div class="chat-container">


### PR DESCRIPTION
##  작업 개요
* **목적**: 불필요한 서버 자원 소모를 방지하고, 송출자와 시청자 간의 실시간 인원수 데이터 정합성을 확보하기 위함
* **배경**: 기존 `@Scheduled` 방식은 방송 유무와 상관없이 전역적으로 실행되어 확장성(Scalability)에 한계가 있었으며, 송출자(Presenter) 세션이 집계 대상에서 제외되어 송출측 UI 업데이트가 불가능했던 문제를 해결
***
## 주요 변경 사항
* **동적 스케줄러(`TaskScheduler`) 도입**: 
    - 고정 주기 스케줄러 대신 방송 시작/종료 시점에 맞춰 작동하는 `DynamicLiveScheduler` 구현
    - `Map<Long, ScheduledFuture<?>>`를 통해 각 방송(`streamNo`)별 독립적인 생명주기 관리
* **조회 및 전송 로직 최적화**:
    - 전체 세션 전수 조사 방식에서 특정 `streamNo` 타겟팅 필터링으로 변경 ($O(N)$ 최적화).
    - `Long` 타입 `streamNo`를 기반으로 한 타입 안정성 확보 및 세션 어트리뷰트 비교 로직 정교화
* **송출자-시청자 통합 브로드캐스팅**:
    - `viewers` 맵(시청자)과 `presenterUserSession`(송출자)을 동시에 조회하여 동일한 `viewerCountUpdate` 이벤트 전송
***
## 주요 이슈
* **자원 효율성 및 고가용성**: 
    - 방송이 종료될 때 스케줄러를 명시적으로 `cancel` 처리하여 메모리 누수 방지
    - `ThreadPoolTaskScheduler` 설정을 통해 여러 방송이 동시 진행될 때의 병렬 처리 능력 확보
* **동기화 및 안정성**:
    - 웹소켓 전송 시 `synchronized` 블록을 활용하여 세션 경합 상태(Race Condition) 방지
***